### PR TITLE
Minor makefile changes and some initial analytic tests added v2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,10 @@ ifeq ($(TEST), true)
   $(info )
   SUFFIX    := $(strip $(SUFFIX)).tests
   CPPFILES  := $(filter-out src/main.cpp,$(CPPFILES))
-  TEST_FLAGS = -lgtest \
-               -I$(GOOGLETEST_ROOT)/include \
-               -L$(GOOGLETEST_ROOT)/lib64 \
-               -lpthread
+  LIBS      += -L$(GOOGLETEST_ROOT)/lib64 -lpthread -lgtest -lhdf5_cpp
+  TEST_FLAGS = -I$(GOOGLETEST_ROOT)/include
   CFLAGS   = $(TEST_FLAGS)
-  CXXFLAGS = $(TEST_FLAGS) -lhdf5_cpp
+  CXXFLAGS = $(TEST_FLAGS)
   GPUFLAGS = $(TEST_FLAGS)
 else
   # This isn't a test build so clear out testing related files

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -12,6 +12,10 @@
 // Local includes
 #include "../system_tests/system_tester.h"
 
+#ifndef PI
+#define PI 3.141592653589793
+#endif
+
 TEST(tHYDROSYSTEMSodShockTube,
      CorrectInputExpectCorrectOutput)
 {
@@ -29,4 +33,22 @@ TEST(tHYDROSYSTEMConstant,
   systemTest::systemTestDatasetIsConstant(testDataFile,"momentum_z",0.0);
   systemTest::systemTestDatasetIsConstant(testDataFile,"Energy",1.5e-5);  
 
+}
+
+TEST(tHYDROSYSTEMSoundWave3D,
+     CorrectInputExpectCorrectOutput)
+{
+  H5::H5File testDataFile;
+  double time = 0.05;
+  double amplitude = 1e-4;
+  double dx = 1./64.;
+    
+  double real_kx = 2*PI;//kx of the physical problem
+  
+  double kx = real_kx * dx;
+  double speed = 1;//speed of wave is 1 since P = 0.6 and gamma = 1.666667
+  double phase = kx*0.5 - speed * time * real_kx; //kx*0.5 for half-cell offset
+  double tolerance = 1e-7;
+  systemTest::systemTestRunAndLoad(testDataFile);
+  systemTest::systemTestDatasetIsSinusoid(testDataFile,"density",1.0,amplitude,kx,0.0,0.0,phase,tolerance);
 }

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -40,7 +40,7 @@ TEST(tHYDROSYSTEMSoundWave3D,
 {
   H5::H5File testDataFile;
   double time = 0.05;
-  double amplitude = 1e-4;
+  double amplitude = 1e-5;
   double dx = 1./64.;
     
   double real_kx = 2*PI;//kx of the physical problem

--- a/src/system_tests/hydro_system_tests.cpp
+++ b/src/system_tests/hydro_system_tests.cpp
@@ -17,3 +17,16 @@ TEST(tHYDROSYSTEMSodShockTube,
 {
     systemTest::systemTestRunner();
 }
+
+TEST(tHYDROSYSTEMConstant,
+     CorrectInputExpectCorrectOutput)
+{
+  H5::H5File testDataFile;
+  systemTest::systemTestRunAndLoad(testDataFile);
+  systemTest::systemTestDatasetIsConstant(testDataFile,"density",1.0);
+  systemTest::systemTestDatasetIsConstant(testDataFile,"momentum_x",0.0);
+  systemTest::systemTestDatasetIsConstant(testDataFile,"momentum_y",0.0);
+  systemTest::systemTestDatasetIsConstant(testDataFile,"momentum_z",0.0);
+  systemTest::systemTestDatasetIsConstant(testDataFile,"Energy",1.5e-5);  
+
+}

--- a/src/system_tests/input_files/tHYDROSYSTEMConstant_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROSYSTEMConstant_CorrectInputExpectCorrectOutput.txt
@@ -1,0 +1,44 @@
+#
+# Parameter File for 3D Constant
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=32
+# number of grid cells in the y dimension
+ny=32
+# number of grid cells in the z dimension
+nz=32
+# final output time
+tout=100
+# time interval for output
+outstep=100
+# name of initial conditions
+init=Constant
+# domain properties
+xmin=0.0
+ymin=0.0
+zmin=0.0
+xlen=1.0
+ylen=1.0
+zlen=1.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+rho=1.0
+# velocity
+vx=0
+vy=0
+vz=0
+# pressure
+P=1e-5
+# value of gamma
+gamma=1.666666667

--- a/src/system_tests/input_files/tHYDROSYSTEMSoundWave3D_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROSYSTEMSoundWave3D_CorrectInputExpectCorrectOutput.txt
@@ -1,0 +1,51 @@
+#
+# Parameter File for sound wave test
+#
+
+################################################
+# number of grid cells in the x dimension
+nx=64
+# number of grid cells in the y dimension
+ny=64
+# number of grid cells in the z dimension
+nz=64
+# final output time
+tout=0.05
+# time interval for output
+outstep=0.05
+# name of initial conditions
+init=Sound_Wave
+# domain properties
+xmin=0.0
+ymin=0.0
+zmin=0.0
+xlen=1.0
+ylen=1.0
+zlen=1.0
+# type of boundary conditions
+xl_bcnd=1
+xu_bcnd=1
+yl_bcnd=1
+yu_bcnd=1
+zl_bcnd=1
+zu_bcnd=1
+# path to output directory
+outdir=./
+
+#################################################
+# Parameters for linear wave problems
+# initial density 
+rho=1.0
+# velocity in the x direction 
+vx=0
+# velocity in the y direction
+vy=0
+# velocity in the z direction
+vz=0
+# initial pressure 
+P=0.6
+# amplitude of perturbing oscillations
+A=1e-4
+# value of gamma
+gamma=1.666666666666667
+

--- a/src/system_tests/input_files/tHYDROSYSTEMSoundWave3D_CorrectInputExpectCorrectOutput.txt
+++ b/src/system_tests/input_files/tHYDROSYSTEMSoundWave3D_CorrectInputExpectCorrectOutput.txt
@@ -45,7 +45,7 @@ vz=0
 # initial pressure 
 P=0.6
 # amplitude of perturbing oscillations
-A=1e-4
+A=1e-5
 # value of gamma
 gamma=1.666666666666667
 

--- a/src/system_tests/system_tester.h
+++ b/src/system_tests/system_tester.h
@@ -7,6 +7,8 @@
  */
 
 #pragma once
+#include <string>
+#include <H5Cpp.h>
 
 /*!
  * \brief The namespace that contains the function for running system tests.
@@ -41,4 +43,11 @@ namespace systemTest
      *
      */
     void systemTestRunner();
+
+    /*!
+     * \brief First half of systemTest which runs cholla and loads the HDF5 output
+     */
+    void systemTestRunAndLoad(H5::H5File &testDataFile);
+    void systemTestDatasetIsConstant(H5::H5File &testDataFile, std::string datasetName, double value);
+
 } // namespace systemTest

--- a/src/system_tests/system_tester.h
+++ b/src/system_tests/system_tester.h
@@ -49,5 +49,15 @@ namespace systemTest
      */
     void systemTestRunAndLoad(H5::H5File &testDataFile);
     void systemTestDatasetIsConstant(H5::H5File &testDataFile, std::string datasetName, double value);
+    void systemTestDatasetIsSinusoid(H5::H5File &testDataFile,
+                                     std::string datasetName,
+                                     double constant,
+                                     double amplitude,
+                                     double kx,
+                                     double ky,
+                                     double kz,
+                                     double phase,
+				     double tolerance);
 
+  
 } // namespace systemTest


### PR DESCRIPTION
Moved -L and -l flags into LIBS as they are only needed during linking (leading to harmless errors like this: clang-12: warning: -lhdf5_cpp: 'linker' input unused [-Wunused-command-line-argument])

mkdir -> mkdir -p, which is much better behaved

slight change to generatePathsAndCheckFiles which adds an optional argument in cases where fiducial file check is not wanted (no change in behavior when this additional argument is missing)

Constant and Sinusoid analytic functions added, for checking individual fields
Constant and Sinusoid example test problems added